### PR TITLE
Replace '.' with '_' to make Jenkins happy & strip cwd

### DIFF
--- a/lib/rspec/core/formatters/j_unit_formatter.rb
+++ b/lib/rspec/core/formatters/j_unit_formatter.rb
@@ -50,6 +50,7 @@ class RSpec::Core::Formatters::JUnitFormatter < RSpec::Core::Formatters::BaseFor
   end
 
   def classname example
+    example = example[Dir.pwd.length+1..-1] if example.start_with? Dir.pwd
     example.gsub /\./, '_'
   end
 


### PR DESCRIPTION
Minor issue: The '.rb' postfix led Jenkins to believe that there was a subpackage under every spec called 'rb' ...  By replacing '.' with '_' jenkins is less confused.

Also, strip current working directory from the spec path to normalize classname.
