### PR TITLE
Add support for RSpec 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rspec", "~> 2.14"
+gem "rspec", "~> 3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,7 @@ PATH
   specs:
     rspec_junit_formatter (0.1.6)
       builder
-      rspec (~> 2.0)
-      rspec-core (!= 2.12.0)
+      rspec (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,19 +13,23 @@ GEM
     mini_portile (0.6.0)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   nokogiri
-  rspec (~> 2.14)
+  rspec (~> 3.0.0)
   rspec_junit_formatter!

--- a/example/spec/example_spec.rb
+++ b/example/spec/example_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe "some example specs" do
   it "should succeed" do
-    true.should be_true
+    expect(true).to be_truthy
   end
 
   it "should fail" do
-    false.should be_true
+    expect(false).to be_truthy
   end
 
   it "should raise" do
@@ -14,6 +14,6 @@ describe "some example specs" do
   end
 
   it "should be pending" do
-    pending
+    skip
   end
 end

--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/lib/rspec/core/formatters/j_unit_formatter.rb
+++ b/lib/rspec/core/formatters/j_unit_formatter.rb
@@ -3,23 +3,42 @@ require 'time'
 # Dumps rspec results as a JUnit XML file.
 # Based on XML schema: http://windyroad.org/dl/Open%20Source/JUnit.xsd
 class RSpec::Core::Formatters::JUnitFormatter < RSpec::Core::Formatters::BaseFormatter
+  RSpec::Core::Formatters.register self,
+    :start, :example_passed, :example_pending, :example_failed, :dump_summary,
+    :close
+
   def xml
-    @xml ||= Builder::XmlMarkup.new :target => output, :indent => 2 
+    @xml ||= Builder::XmlMarkup.new :target => output, :indent => 2
   end
 
-  def start example_count
+  def initialize(output)
+    super
+    @example_notifications = []
+  end
+
+  def start(notification)
     @start = Time.now
     super
   end
 
-  def dump_summary duration, example_count, failure_count, pending_count
-    super
+  def example_passed(notification)
+    @example_notifications << notification
+  end
 
+  def example_pending(notification)
+    @example_notifications << notification
+  end
+
+  def example_failed(notification)
+    @example_notifications << notification
+  end
+
+  def dump_summary(summary)
     xml.instruct!
-    xml.testsuite :tests => example_count, :failures => failure_count, :errors => 0, :time => '%.6f' % duration, :timestamp => @start.iso8601 do
+    xml.testsuite :tests => summary.example_count, :failures => summary.failure_count, :errors => 0, :time => '%.6f' % summary.duration, :timestamp => @start.iso8601 do
       xml.properties
-      examples.each do |example|
-        send :"dump_summary_example_#{example.execution_result[:status]}", example
+      @example_notifications.each do |notification|
+        send :"dump_summary_example_#{notification.example.execution_result[:status]}", notification
       end
     end
   end
@@ -28,21 +47,21 @@ class RSpec::Core::Formatters::JUnitFormatter < RSpec::Core::Formatters::BaseFor
     xml.testcase :classname => example_classname(example), :name => example.full_description, :time => '%.6f' % example.execution_result[:run_time], &block
   end
 
-  def dump_summary_example_passed example
-    xml_example example
+  def dump_summary_example_passed(notification)
+    xml_example notification.example
   end
 
-  def dump_summary_example_pending example
-    xml_example example do
+  def dump_summary_example_pending(notification)
+    xml_example notification.example do
       xml.skipped
     end
   end
 
-  def dump_summary_example_failed example
-    exception = example.execution_result[:exception]
-    backtrace = format_backtrace exception.backtrace, example
+  def dump_summary_example_failed(notification)
+    exception = notification.exception
+    backtrace = notification.formatted_backtrace
 
-    xml_example example do
+    xml_example notification.example do
       xml.failure :message => exception.to_s, :type => exception.class.name do
         xml.cdata! "#{exception.message}\n#{backtrace.join "\n"}"
       end

--- a/rspec_junit_formatter.gemspec
+++ b/rspec_junit_formatter.gemspec
@@ -12,9 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "rspec", "~> 2.0"
-  # https://github.com/rspec/rspec-core/commit/f06254c00770387e3a8a2efbdbc973035c217f6a
-  s.add_dependency "rspec-core", "!= 2.12.0"
+  s.add_dependency "rspec", "~> 3.0"
   s.add_dependency "builder"
 
   s.add_development_dependency "nokogiri"


### PR DESCRIPTION
Adds support for RSpec 3.0

Major version should be bumped since it's not backwards compatible. 
Older versions should be used for RSpec ~> 2.14.
