### PR TITLE
differentiate suite names in a parallel_tests context

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -18,7 +18,7 @@ private
 
   def xml_dump
     xml.instruct!
-    xml.testsuite name: "rspec", tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
+    xml.testsuite name: "rspec#{ENV['TEST_ENV_NUMBER']}", tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
       xml.properties
       xml_dump_examples
     end

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -17,6 +17,7 @@ describe RspecJunitFormatter do
 
   before(:all) do
     Dir.chdir EXAMPLE_DIR do
+      ENV['TEST_ENV_NUMBER'] = '2'
       system "bundle", "exec", "rspec"
     end
   end
@@ -26,6 +27,7 @@ describe RspecJunitFormatter do
 
     expect(root.name).to eq "testsuite"
 
+    expect(root["name"]).to eq "rspec2"
     expect(root["tests"]).to eq "4"
     expect(root["failures"]).to eq "2"
     expect(root["errors"]).to eq "0"


### PR DESCRIPTION
When using the formatter with parallel tests (https://github.com/grosser/parallel_tests), we ran into issues with Jenkins dropping one or more of the test result files' data (i.e., failing to include it in reports/tallies), apparently because all of the `testsuite` elements have the same name (specifically, `rspec`).

To fix that issue, this PR transparently leverages the parallel_tests environment variable `TEST_ENV_NUMBER`, if it is present, to make the suite names unique (cf. https://github.com/grosser/parallel_tests#add-to-configdatabaseyml), by simply appending it.