### PR TITLE
Adding sub-suites per describe block

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -18,7 +18,7 @@ private
 
   def xml_dump
     xml.instruct!
-    xml.testsuite name: "rspec", tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
+    xml.testsuite name: suite_name, tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
       xml.properties
       xml_dump_examples
     end

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -18,17 +18,45 @@ private
 
   def xml_dump
     xml.instruct!
-    xml.testsuite name: suite_name, tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
-      xml.properties
-      xml_dump_examples
+    xml.testsuites do
+      xml.testsuite name: "rspec", tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
+        xml.properties
+        xml_dump_suites
+      end
     end
   end
 
-  def xml_dump_examples
+  def xml_dump_suites
+    current_suite = nil
+    current_examples = []
     examples.each do |example|
+      current_suite ||= suite_name example
+      if current_suite != suite_name(example)
+        xml_dump_suite(current_examples, current_suite)
+
+        current_examples = []
+        current_suite = suite_name example
+
+      end
+      current_examples << example
+    end
+    xml_dump_suite(current_examples, current_suite)
+
+  end
+
+  def xml_dump_suite suite_examples, suite
+    return unless (suite_examples.length > 0)
+    xml.testsuite name: suite, tests: suite_examples.length do
+        xml_dump_examples suite_examples
+    end
+  end
+
+  def xml_dump_examples suite_examples
+    suite_examples.each do |example|
       send :"xml_dump_#{result_of(example)}", example
     end
   end
+
 
   def xml_dump_passed(example)
     xml_dump_example(example)

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -1,3 +1,5 @@
+require 'pp'
+
 class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
   attr_reader :started
 
@@ -24,7 +26,7 @@ private
   end
 
   def classname_for(example)
-    example.file_path.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
+    example.metadata[:example_group][:description_args].join(" ")
   end
 
   def duration_for(example)
@@ -32,7 +34,7 @@ private
   end
 
   def description_for(example)
-    example.full_description
+    example.full_description.replace(classname_for(example))
   end
 
   def exception_for(example)

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
   attr_reader :started
 
@@ -15,6 +13,15 @@ class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
 
 private
 
+  def suite_name
+    if examples.length
+      example = examples[0]
+      example.full_description.gsub(example.description, "").strip
+    else
+      ""
+    end
+  end
+
   def xml_dump_examples
     examples.each do |example|
       send :"xml_dump_#{example.execution_result[:status]}", example
@@ -26,7 +33,7 @@ private
   end
 
   def classname_for(example)
-    example.metadata[:example_group][:description_args].join(" ")
+    example.file_path.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
   end
 
   def duration_for(example)
@@ -34,7 +41,7 @@ private
   end
 
   def description_for(example)
-    example.full_description.replace(classname_for(example))
+    example.description
   end
 
   def exception_for(example)

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -13,19 +13,8 @@ class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
 
 private
 
-  def suite_name
-    if examples.length
-      example = examples[0]
-      example.full_description.gsub(example.description, "").strip
-    else
-      ""
-    end
-  end
-
-  def xml_dump_examples
-    examples.each do |example|
-      send :"xml_dump_#{example.execution_result[:status]}", example
-    end
+  def suite_name example
+    example.full_description.gsub(example.description, "").strip
   end
 
   def result_of(example)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -23,13 +23,8 @@ private
 
   attr_reader :started
 
-  def suite_name
-    if @summary_notification.examples.length
-      example = @summary_notification.examples[0]
-      example.full_description.gsub(example.description, "").strip
-    else
-      ""
-    end
+  def suite_name notification
+    notification.example.full_description.gsub(notification.example.description, "").strip
   end
 
   def example_count
@@ -61,7 +56,7 @@ private
   end
 
   def description_for(notification)
-    notification.example.full_description
+    notification.example.description
   end
 
   def exception_for(notification)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -23,6 +23,15 @@ private
 
   attr_reader :started
 
+  def suite_name
+    if @summary_notification.examples.length
+      example = @summary_notification.examples[0]
+      example.full_description.gsub(example.description, "").strip
+    else
+      ""
+    end
+  end
+
   def example_count
     @summary_notification.examples.count
   end

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -9,11 +9,11 @@ describe RspecJunitFormatter do
   let(:output_xml) { IO.read(output_path) }
   let(:output_doc) { Nokogiri::XML::Document.parse(output_xml) }
 
-  let(:root) { output_doc.xpath("/testsuite").first }
-  let(:testcases) { output_doc.xpath("/testsuite/testcase") }
-  let(:successful_testcases) { output_doc.xpath("/testsuite/testcase[count(*)=0]") }
-  let(:pending_testcases) { output_doc.xpath("/testsuite/testcase[skipped]") }
-  let(:failed_testcases) { output_doc.xpath("/testsuite/testcase[failure]") }
+  let(:root) { output_doc.xpath("/testsuites/testsuite").first }
+  let(:testcases) { output_doc.xpath("/testsuites/testsuite/testsuite/testcase") }
+  let(:successful_testcases) { output_doc.xpath("/testsuites/testsuite/testsuite/testcase[count(*)=0]") }
+  let(:pending_testcases) { output_doc.xpath("/testsuites/testsuite/testsuite/testcase[skipped]") }
+  let(:failed_testcases) { output_doc.xpath("/testsuites/testsuite/testsuite/testcase[failure]") }
 
   before(:all) do
     Dir.chdir EXAMPLE_DIR do


### PR DESCRIPTION
Hi I don't know what you think of this, but at BBC sport we need to output our JUNIT with subsuites per describe block so we can get a better breakdown of code coverage.

The PHPUNIT Junit formatter does this similarly.
