### PR TITLE
Print the used seed as a comment

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -19,6 +19,7 @@ private
   def xml_dump
     xml.instruct!
     xml.testsuite name: "rspec", tests: example_count, failures: failure_count, errors: 0, time: "%.6f" % duration, timestamp: started.iso8601 do
+      xml.comment! "Randomized with seed #{RSpec.configuration.seed}"
       xml.properties
       xml_dump_examples
     end

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -10,6 +10,7 @@ describe RspecJunitFormatter do
   let(:output_doc) { Nokogiri::XML::Document.parse(output_xml) }
 
   let(:root) { output_doc.xpath("/testsuite").first }
+  let(:seed_comment) { output_doc.xpath("/testsuite/comment()").first }
   let(:testcases) { output_doc.xpath("/testsuite/testcase") }
   let(:successful_testcases) { output_doc.xpath("/testsuite/testcase[count(*)=0]") }
   let(:pending_testcases) { output_doc.xpath("/testsuite/testcase[skipped]") }
@@ -76,5 +77,9 @@ describe RspecJunitFormatter do
       expect(child["message"]).not_to be_empty
       expect(child.text.strip).not_to be_empty
     end
+  end
+
+  it "has a comment with seed info" do
+    expect(seed_comment.to_s).to match /randomized with seed \d/i
   end
 end


### PR DESCRIPTION
Sometimes when your tests have an ordering dependency (i.e. examples fail intermittently depending on order) you need to know the seed to reproduce that dependency. 
This change will result in a top-level comment containing the seed. I did not implement it as an attribute to avoid clashes with the XML schema.

Note: As I understand from https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters.rb you should overwrite the method `seed(number)` to produce that output, but this method never gets called. And even if, it would be after the XML dump.