### PR TITLE
Add file information to XML report

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -52,7 +52,7 @@ private
   end
 
   def xml_dump_example(example, &block)
-    xml.testcase classname: classname_for(example), name: description_for(example), time: "%.6f" % duration_for(example), &block
+    xml.testcase classname: classname_for(example), name: description_for(example), file: example_group_file_path_for(example), time: "%.6f" % duration_for(example), &block
   end
 end
 

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -23,8 +23,17 @@ private
     example.execution_result[:status]
   end
 
+  def example_group_file_path_for(example)
+    meta = example.metadata
+    while meta[:example_group]
+      meta = meta[:example_group]
+    end
+    meta[:file_path]
+  end
+
   def classname_for(example)
-    example.file_path.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
+    fp = example_group_file_path_for(example)
+    fp.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
   end
 
   def duration_for(example)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -43,8 +43,17 @@ private
     notification.example.execution_result.status
   end
 
+  def example_group_file_path_for(notification)
+    meta = notification.example.metadata
+    while meta[:example_group]
+      meta = meta[:example_group]
+    end
+    meta[:file_path]
+  end
+
   def classname_for(notification)
-    notification.example.file_path.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")
+    fp = example_group_file_path_for(notification)
+    fp.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")
   end
 
   def duration_for(notification)


### PR DESCRIPTION
This PR adds file information to the XML report to make it easier for tools like CircleCI to produce helpful build reports.