### PR TITLE
Only depend on rspec-core.

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -1,8 +1,7 @@
 require "time"
-
 require "builder"
-require "rspec"
 
+require "rspec/core/version"
 require "rspec/core/formatters/base_formatter"
 
 # Dumps rspec results as a JUnit XML file.
@@ -59,8 +58,8 @@ end
 
 RspecJunitFormatter = RSpecJUnitFormatter
 
-if RSpec::Version::STRING.start_with? "3."
+if RSpec::Core::Version::STRING.start_with? "3."
   require "rspec_junit_formatter/rspec3"
-else RSpec::Version::STRING.start_with? "2."
+else RSpec::Core::Version::STRING.start_with? "2."
   require "rspec_junit_formatter/rspec2"
 end

--- a/rspec_junit_formatter.gemspec
+++ b/rspec_junit_formatter.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "rspec", ">= 2", "< 4"
   # https://github.com/rspec/rspec-core/commit/f06254c00770387e3a8a2efbdbc973035c217f6a
-  s.add_dependency "rspec-core", "!= 2.12.0"
+  s.add_dependency "rspec-core", ">= 2", "< 4", "!= 2.12.0"
   s.add_dependency "builder", "< 4"
 
   s.add_development_dependency "nokogiri", "~> 1.6"


### PR DESCRIPTION
The things we need are all in rspec-core, so we don't need to depend
on the rspec meta-package. Many people use the rspec-rails meta-package
and causing the other to be added as a dependency is a bit unfriendly.