### PR TITLE
Don't assign to a variable we don't use.

### DIFF
--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -60,6 +60,6 @@ private
   end
 
   def formatted_backtrace_for(notification)
-    backtrace = notification.formatted_backtrace
+    notification.formatted_backtrace
   end
 end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -4,6 +4,8 @@ class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
     :stop,
     :dump_summary
 
+  attr_reader :started
+
   def start(notification)
     @start_notification = notification
     @started = Time.now
@@ -20,8 +22,6 @@ class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
   end
 
 private
-
-  attr_reader :started
 
   def example_count
     @summary_notification.examples.count


### PR DESCRIPTION
Fixes #15.