### PR TITLE
fix(example_group): fix RSpec3 deprecation error when determining example file path

### DIFF
--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -44,11 +44,7 @@ private
   end
 
   def example_group_file_path_for(notification)
-    meta = notification.example.metadata
-    while meta[:example_group]
-      meta = meta[:example_group]
-    end
-    meta[:file_path]
+    notification.example.example_group.file_path
   end
 
   def classname_for(notification)


### PR DESCRIPTION
Fixes https://github.com/sj26/rspec_junit_formatter/issues/28

Not too familiar with RSpec API, but this seems proper to me. Would be nice to bump the version again, if this gets merged.