### PR TITLE
Add line_number to output

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -52,7 +52,7 @@ private
   end
 
   def xml_dump_example(example, &block)
-    xml.testcase classname: classname_for(example), name: description_for(example), file: example_group_file_path_for(example), time: "%.6f" % duration_for(example), &block
+    xml.testcase classname: classname_for(example), name: description_for(example), file: example_group_file_path_for(example), line_number: line_number_for(example), time: "%.6f" % duration_for(example), &block
   end
 end
 

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -51,4 +51,8 @@ private
   def formatted_backtrace_for(example)
     format_backtrace exception_for(example).backtrace, example
   end
+
+  def line_number_for(example)
+    example.metadata[:line_number]
+  end
 end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -67,4 +67,8 @@ private
   def formatted_backtrace_for(notification)
     notification.formatted_backtrace
   end
+
+  def line_number_for(notification)
+    notification.example.metadata[:line_number]
+  end
 end


### PR DESCRIPTION
This adds a `line_number` attribute to each example in the XML output. I tested it locally with RSpec 3. 