### PR TITLE
Report line number of inclusion of shared example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /example/tmp
+/example_with_shared/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ gemfile:
   - gemfiles/Gemfile.rspec2
   - gemfiles/Gemfile.rspec3-0
   - gemfiles/Gemfile.rspec3-1
+  - gemfiles/Gemfile.rspec3-2
+  - gemfiles/Gemfile.rspec3-3
+  - gemfiles/Gemfile.rspec3-4
 script: bundle exec rspec

--- a/example_with_shared/.rspec
+++ b/example_with_shared/.rspec
@@ -1,0 +1,2 @@
+--format RspecJunitFormatter
+--out tmp/rspec.xml

--- a/example_with_shared/spec/shared.rb
+++ b/example_with_shared/spec/shared.rb
@@ -1,0 +1,8 @@
+# example_shared.rb
+
+RSpec.shared_examples "shared specs" do |collection_class|
+  it "does not pass" do
+    expect(1).to eq(2)
+  end
+end
+

--- a/example_with_shared/spec/shared_including_spec.rb
+++ b/example_with_shared/spec/shared_including_spec.rb
@@ -1,0 +1,10 @@
+# shared_including_spec
+require File.expand_path('../shared', __FILE__)
+
+RSpec.describe "A spec" do
+  context "a context" do
+    #The line where it is included:
+    include_examples "shared specs", Array
+  end
+end
+

--- a/gemfiles/Gemfile.rspec3-2
+++ b/gemfiles/Gemfile.rspec3-2
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => ".."
+
+gem "rspec", "~> 3.2.0"

--- a/gemfiles/Gemfile.rspec3-2.lock
+++ b/gemfiles/Gemfile.rspec3-2.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: ..
+  specs:
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.6)
+  rspec (~> 3.2.0)
+  rspec_junit_formatter!
+
+BUNDLED WITH
+   1.12.3

--- a/gemfiles/Gemfile.rspec3-3
+++ b/gemfiles/Gemfile.rspec3-3
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => ".."
+
+gem "rspec", "~> 3.3.0"

--- a/gemfiles/Gemfile.rspec3-3.lock
+++ b/gemfiles/Gemfile.rspec3-3.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: ..
+  specs:
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.6)
+  rspec (~> 3.3.0)
+  rspec_junit_formatter!
+
+BUNDLED WITH
+   1.12.3

--- a/gemfiles/Gemfile.rspec3-4
+++ b/gemfiles/Gemfile.rspec3-4
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => ".."
+
+gem "rspec", "~> 3.4.0"

--- a/gemfiles/Gemfile.rspec3-4.lock
+++ b/gemfiles/Gemfile.rspec3-4.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: ..
+  specs:
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.6)
+  rspec (~> 3.4.0)
+  rspec_junit_formatter!
+
+BUNDLED WITH
+   1.12.3

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -51,15 +51,15 @@ private
     end
   end
 
-if ["2.", "3.0", "3.1" ].any?{|v| RSpec::Core::Version::STRING.start_with? v }
+if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.2")
+  def fully_formatted_failure_for(index, notification)
+    notification.fully_formatted(index, RSpec::Core::Notifications::NullColorizer)
+  end
+else
   def fully_formatted_failure_for(index, notification)
     exception = exception_for(notification)
     backtrace = formatted_backtrace_for(notification)
     "#{exception.message}\n#{backtrace.join "\n"}"
-  end
-else
-  def fully_formatted_failure_for(index, notification)
-    notification.fully_formatted(index, RSpec::Core::Notifications::NullColorizer)
   end
 end
 

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -42,13 +42,18 @@ private
 
   def xml_dump_failed(example)
     exception = exception_for(example)
-    backtrace = formatted_backtrace_for(example)
 
     xml_dump_example(example) do
       xml.failure message: exception.to_s, type: exception.class.name do
-        xml.cdata! "#{exception.message}\n#{backtrace.join "\n"}"
+        xml.cdata! text_for_failing_example(example)
       end
     end
+  end
+
+  def text_for_failing_example(example)
+    exception = exception_for(example)
+    backtrace = formatted_backtrace_for(example)
+    "#{exception.message}\n#{backtrace.join "\n"}"
   end
 
   def xml_dump_example(example, &block)

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -41,24 +41,33 @@ private
   end
 
   def xml_dump_failed(example)
+    @failure_index = (@failure_index || 0) + 1
     exception = exception_for(example)
 
     xml_dump_example(example) do
       xml.failure message: exception.to_s, type: exception.class.name do
-        xml.cdata! text_for_failing_example(example)
+        xml.cdata! fully_formatted_failure_for(@failure_index, example)
       end
     end
   end
 
-  def text_for_failing_example(example)
-    exception = exception_for(example)
-    backtrace = formatted_backtrace_for(example)
+if ["2.", "3.0", "3.1" ].any?{|v| RSpec::Core::Version::STRING.start_with? v }
+  def fully_formatted_failure_for(index, notification)
+    exception = exception_for(notification)
+    backtrace = formatted_backtrace_for(notification)
     "#{exception.message}\n#{backtrace.join "\n"}"
   end
+else
+  def fully_formatted_failure_for(index, notification)
+    notification.fully_formatted(index, RSpec::Core::Notifications::NullColorizer)
+  end
+end
 
   def xml_dump_example(example, &block)
     xml.testcase classname: classname_for(example), name: description_for(example), file: example_group_file_path_for(example), time: "%.6f" % duration_for(example), &block
   end
+
+
 end
 
 RspecJunitFormatter = RSpecJUnitFormatter

--- a/spec/using_shared_spec.rb
+++ b/spec/using_shared_spec.rb
@@ -20,14 +20,13 @@ describe "Shared spec" do
     end
   end
 
-  it "failed test case includes reference to failure line and original including line" do
+  it "failed test case includes reference to failure line and original including line when supported" do
     expect(failed_testcases.size).to be 1 # otherwise, we have to find the specific one in multiple, potentially random
     failure_element = failed_testcases.first.element_children.first
     expect(failure_element.text).to include("spec/shared.rb:5")
-    if ["2.", "3.0", "3.1"].any?{|v|RSpec::Core::Version::STRING.start_with?(v)}
-      pending "no shared-example reporting below 3.2"
+    if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.2")
+      expect(failure_element.text).to include("spec/shared_including_spec.rb:7")
     end
-    expect(failure_element.text).to include("spec/shared_including_spec.rb:7")
   end
 
 end

--- a/spec/using_shared_spec.rb
+++ b/spec/using_shared_spec.rb
@@ -1,0 +1,33 @@
+require "nokogiri"
+
+require "rspec_junit_formatter"
+
+describe "Shared spec" do
+  EXAMPLE_WITH_SHARED_DIR = File.expand_path("../../example_with_shared", __FILE__)
+
+  let(:output_path) { File.join(EXAMPLE_WITH_SHARED_DIR , "tmp/rspec.xml") }
+  let(:output_xml) { IO.read(output_path) }
+  let(:output_doc) { Nokogiri::XML::Document.parse(output_xml) }
+
+  let(:root) { output_doc.xpath("/testsuite").first }
+  let(:testcases) { output_doc.xpath("/testsuite/testcase") }
+  let(:failed_testcases) { output_doc.xpath("/testsuite/testcase[failure]") }
+
+
+  before(:all) do
+    Dir.chdir EXAMPLE_WITH_SHARED_DIR  do
+      system "bundle", "exec", "rspec", "spec/shared_including_spec.rb"
+    end
+  end
+
+  it "failed test case includes reference to failure line and original including line" do
+    expect(failed_testcases.size).to be 1 # otherwise, we have to find the specific one in multiple, potentially random
+    failure_element = failed_testcases.first.element_children.first
+    expect(failure_element.text).to include("spec/shared.rb:5")
+    if ["2.", "3.0", "3.1"].any?{|v|RSpec::Core::Version::STRING.start_with?(v)}
+      pending "no shared-example reporting below 3.2"
+    end
+    expect(failure_element.text).to include("spec/shared_including_spec.rb:7")
+  end
+
+end


### PR DESCRIPTION
Rspec 3.2+ reports the line number that shared example.
<img width="589" alt="reporing_shared_example_group" src="https://cloud.githubusercontent.com/assets/18395/15183960/47941c64-178b-11e6-82cf-1c8ae7726cc5.png">

It's easy enough to include this in the CDATA by using Rspec's own helper.

BTW I think it would be nicer to use the [semantic gem](https://github.com/jlindsey/semantic) to manage the version comparison rather than string starts_with?. Would you be averse to including that gem?
