### PR TITLE
use `result_of` to remove duplication

### DIFF
--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -15,7 +15,7 @@ private
 
   def xml_dump_examples
     examples.each do |example|
-      send :"xml_dump_#{example.execution_result[:status]}", example
+      send :"xml_dump_#{result_of(example)}", example
     end
   end
 


### PR DESCRIPTION
A few lines below there is a method `result_of` to do the execution result lookup. 🍡 