### PR TITLE
Fix Ruby Warnings

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -78,11 +78,9 @@ private
   ILLEGAL_REGEXP = Regexp.new(
     "[^" <<
     "\u{9}" << # => \t
-    "\u{a}" << # =>\n
+    "\u{a}" << # => \n
     "\u{d}" << # => \r
     "\u{20}-\u{d7ff}" <<
-    "\u{28}-\u{3b}" <<
-    "\u{3d}" <<
     "\u{e000}-\u{fffd}" <<
     "\u{10000}-\u{10ffff}" <<
     "]"

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -53,8 +53,6 @@ private
   end
 
   def xml_dump_failed(example)
-    exception = exception_for(example)
-
     xml_dump_example(example) do
       output << %{<failure}
       output << %{ message="#{escape(failure_message_for(example))}"}


### PR DESCRIPTION
Running tests with ruby warnings on highlights two warnings:
- lib/rspec_junit_formatter.rb:56: warning: assigned but unused variable - exception
- lib/rspec_junit_formatter.rb:80: warning: character class has duplicated range

This PR fixes both.

**Original Output:**
```
$ RUBYOPT=-w bundle exec rspec
/Users/tonyta/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-2.14.8/lib/rspec/core/ruby_project.rb:27: warning: File.exists? is a deprecated name, use File.exist? instead
/Users/tonyta/rspec_junit_formatter/lib/rspec_junit_formatter.rb:56: warning: assigned but unused variable - exception
/Users/tonyta/rspec_junit_formatter/lib/rspec_junit_formatter.rb:80: warning: character class has duplicated range: /[^
 -퟿(-;=-�𐀀-􏿿]/
/Users/tonyta/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-2.14.8/lib/rspec/core/ruby_project.rb:27: warning: File.exists? is a deprecated name, use File.exist? instead
/Users/tonyta/rspec_junit_formatter/lib/rspec_junit_formatter.rb:56: warning: assigned but unused variable - exception
/Users/tonyta/rspec_junit_formatter/lib/rspec_junit_formatter.rb:80: warning: character class has duplicated range: /[^
 -퟿(-;=-�𐀀-􏿿]/
./Users/tonyta/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-2.14.8/lib/rspec/core/ruby_project.rb:27: warning: File.exists? is a deprecated name, use File.exist? instead
/Users/tonyta/rspec_junit_formatter/lib/rspec_junit_formatter.rb:56: warning: assigned but unused variable - exception
/Users/tonyta/rspec_junit_formatter/lib/rspec_junit_formatter.rb:80: warning: character class has duplicated range: /[^
 -퟿(-;=-�𐀀-􏿿]/
./Users/tonyta/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-2.14.8/lib/rspec/core/ruby_project.rb:27: warning: File.exists? is a deprecated name, use File.exist? instead
.

Finished in 1.11 seconds
```

Hope this is helpful! 😸