### PR TITLE
Conditionally strip all colors from failures

### DIFF
--- a/example/spec/example_spec.rb
+++ b/example/spec/example_spec.rb
@@ -1,6 +1,16 @@
 require_relative "shared_examples"
 
-describe "some example specs" do
+describe "some example specs", with_colors: true do
+  context "without colors", with_colors: false do
+    RSpec.configure do |config|
+      config.strip_junit_format_colors = true
+    end
+
+    it "should fail without color codes" do
+      expect(false).to be(true)
+    end
+  end
+
   it "should succeed" do
     expect(true).to be(true)
   end

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -9,6 +9,10 @@ require "rspec/core/formatters/base_formatter"
 class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter
   # rspec 2 and 3 implements are in separate files.
 
+  RSpec.configure do |config|
+    config.add_setting :strip_junit_format_colors
+  end
+
 private
 
   def xml_dump

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -77,7 +77,7 @@ private
   end
 
   def failure_for(notification)
-    strip_diff_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
+    strip_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
   end
 
   def exception_for(notification)
@@ -86,6 +86,14 @@ private
 
   STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: \e\[0m (?: \n \1 \e\[0m .* )* /x
   STRIP_COLOR_CODES_REGEXP = /\e\[(?:\d+;?)+m/
+
+  def strip_colors(string)
+    if RSpec.configuration.strip_junit_format_colors
+      string.gsub(STRIP_COLOR_CODES_REGEXP, "")
+    else
+      strip_diff_colors(string)
+    end
+  end
 
   def strip_diff_colors(string)
     # XXX: RSpec diffs are appended to the message lines fairly early and will

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -85,7 +85,7 @@ private
   end
 
   STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: \e\[0m (?: \n \1 \e\[0m .* )* /x
-  STRIP_DIFF_COLORS_CODES_REGEXP = /\e\[\d+m/
+  STRIP_COLOR_CODES_REGEXP = /\e\[(?:\d+;?)+m/
 
   def strip_diff_colors(string)
     # XXX: RSpec diffs are appended to the message lines fairly early and will
@@ -97,7 +97,7 @@ private
     # We also only want to target the diff hunks because the failure message
     # itself might legitimately contain ansi escape codes.
     #
-    string.sub(STRIP_DIFF_COLORS_BLOCK_REGEXP) { |match| match.gsub(STRIP_DIFF_COLORS_CODES_REGEXP, "".freeze) }
+    string.sub(STRIP_DIFF_COLORS_BLOCK_REGEXP) { |match| match.gsub(STRIP_COLOR_CODES_REGEXP, "".freeze) }
   end
 end
 


### PR DESCRIPTION
I use RspecJunitFormatter on CircleCI in conjunction with the standard progress formatter.  Circle doesn't format the color codes that RSpec puts in the failure text, which can be distracting when viewing the list of failures.

I don't want to disable colors at the RSpec level, because they are useful (and correctly displayed) in the progress formatter's output.

This change adds a configuration option to in an attempt to make it backwards compatible, you need to opt-in to stripping out all color codes.

This was difficult to test, I couldn't find an easy way to re-run the specs in `example/` with a different configuration value, so instead I added a single example spec that only gets run by the color stripping spec.  I also had to start sending the output to an XML file instead of capturing STDOUT because RSpec outputs the command line options being used when you pass in tags on the command line.

Finally, I modified the regex used to remove color codes, because they can include multiple color values separated by semicolons, e.g. `\e[30;4;12m`