### PR TITLE
add test for colorization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ gemfile:
   - gemfiles/Gemfile.rspec3-4
   - gemfiles/Gemfile.rspec3-5
   - gemfiles/Gemfile.rspec3-6
+  - gemfiles/Gemfile.rspec3-7
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "rspec"
-gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,9 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    method_source (0.9.0)
     mini_portile2 (2.3.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    pry (0.11.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -36,8 +32,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
-  pry
   rake (~> 10.0)
   rspec
   rspec_junit_formatter!

--- a/gemfiles/Gemfile.rspec2-x.lock
+++ b/gemfiles/Gemfile.rspec2-x.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -26,6 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 2.14, < 2.99)

--- a/gemfiles/Gemfile.rspec3-0.lock
+++ b/gemfiles/Gemfile.rspec3-0.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -30,6 +31,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 3.0.0)

--- a/gemfiles/Gemfile.rspec3-1.lock
+++ b/gemfiles/Gemfile.rspec3-1.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -30,6 +31,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 3.1.0)

--- a/gemfiles/Gemfile.rspec3-2.lock
+++ b/gemfiles/Gemfile.rspec3-2.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -31,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 3.2.0)

--- a/gemfiles/Gemfile.rspec3-3.lock
+++ b/gemfiles/Gemfile.rspec3-3.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -31,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 3.3.0)

--- a/gemfiles/Gemfile.rspec3-4.lock
+++ b/gemfiles/Gemfile.rspec3-4.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -31,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 3.4.0)

--- a/gemfiles/Gemfile.rspec3-5.lock
+++ b/gemfiles/Gemfile.rspec3-5.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
     mini_portile2 (2.2.0)
     nokogiri (1.8.0)
@@ -31,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
   rspec (~> 3.5.0)

--- a/gemfiles/Gemfile.rspec3-7
+++ b/gemfiles/Gemfile.rspec3-7
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => ".."
+
+gem "rspec", "~> 3.7.0"

--- a/gemfiles/Gemfile.rspec3-7.lock
+++ b/gemfiles/Gemfile.rspec3-7.lock
@@ -9,23 +9,23 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    mini_portile2 (2.2.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     rake (10.5.0)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
 
 PLATFORMS
   ruby
@@ -35,7 +35,7 @@ DEPENDENCIES
   coderay (~> 1.0)
   nokogiri (~> 1.6)
   rake (~> 10.0)
-  rspec (~> 3.6.0)
+  rspec (~> 3.7.0)
   rspec_junit_formatter!
 
 BUNDLED WITH

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -149,6 +149,22 @@ private
     # Make sure it's utf-8, replace illegal characters with ruby-like escapes, and replace special and discouraged characters with entities
     text.to_s.encode(Encoding::UTF_8).gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT).gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
   end
+
+  STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: (?: \e\[0m )? (?: \n \1 \e\[\d+m .* )* /x
+  STRIP_DIFF_COLORS_CODES_REGEXP = /\e\[\d+m/
+
+  def strip_diff_colors(string)
+    # XXX: RSpec diffs are appended to the message lines fairly early and will
+    # contain ANSI escape codes for colorizing terminal output if the global
+    # rspec configuration is turned on, regardless of which notification lines
+    # we ask for. We need to strip the codes from the diff part of the message
+    # for XML output here.
+    #
+    # We also only want to target the diff hunks because the failure message
+    # itself might legitimately contain ansi escape codes.
+    #
+    string.sub(STRIP_DIFF_COLORS_BLOCK_REGEXP) { |match| match.gsub(STRIP_DIFF_COLORS_CODES_REGEXP, "".freeze) }
+  end
 end
 
 RspecJunitFormatter = RSpecJUnitFormatter

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -69,21 +69,4 @@ private
   def group_and_parent_groups(example)
     example.example_group.parent_groups + [example.example_group]
   end
-
-  def strip_diff_colors(string)
-    in_diff = false
-    string.lines.reduce([]) do |acc, line|
-      if in_diff && line =~ /\A\e\[\d+m/
-        acc << line.gsub(/\e\[\d+m/, '')
-      elsif in_diff
-        in_diff = false
-        acc << line
-      elsif line =~ /\A[ ]*Diff:/
-        in_diff = true
-        acc << line.gsub(/\e\[\d+m/, '')
-      else
-        acc << line
-      end
-    end.join("\n")
-  end
 end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -84,22 +84,6 @@ private
     notification.example.execution_result.exception
   end
 
-  STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: \e\[0m (?: \n \1 \e\[0m .* )* /x
-  STRIP_DIFF_COLORS_CODES_REGEXP = /\e\[\d+m/
-
-  def strip_diff_colors(string)
-    # XXX: RSpec diffs are appended to the message lines fairly early and will
-    # contain ANSI escape codes for colorizing terminal output if the global
-    # rspec configuration is turned on, regardless of which notification lines
-    # we ask for. We need to strip the codes from the diff part of the message
-    # for XML output here.
-    #
-    # We also only want to target the diff hunks because the failure message
-    # itself might legitimately contain ansi escape codes.
-    #
-    string.sub(STRIP_DIFF_COLORS_BLOCK_REGEXP) { |match| match.gsub(STRIP_DIFF_COLORS_CODES_REGEXP, "".freeze) }
-  end
-
   # Completely gross hack for forcing off colorising
   def __without_color
     unset = Object.new

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -101,14 +101,7 @@ private
   end
 
   # Completely gross hack for forcing off colorising
-  if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.6")
-    WITHOUT_COLOR_KEY = :color_mode
-    WITHOUT_COLOR_VALUE = :off
-  else
-    WITHOUT_COLOR_KEY = :color
-    WITHOUT_COLOR_VALUE = false
-  end
-  def without_color
+  def __without_color
     unset = Object.new
     force = RSpec.configuration.send(:value_for, WITHOUT_COLOR_KEY) { unset }
     if unset.equal?(force)
@@ -124,6 +117,18 @@ private
     else
       RSpec.configuration.force({WITHOUT_COLOR_KEY => force})
     end
+  end
+  if RSpec.configuration.respond_to?(:color_mode=)
+    WITHOUT_COLOR_KEY = :color_mode
+    WITHOUT_COLOR_VALUE = :off
+    alias_method :without_color, :__without_color
+  elsif RSpec.configuration.respond_to?(:color=)
+    WITHOUT_COLOR_KEY = :color
+    WITHOUT_COLOR_VALUE = false
+    alias_method :without_color, :__without_color
+  else
+    warn 'rspec_junit_formatter cannot prevent colorising due to an unexpected RSpec.configuration format'
+    def without_color; yield; end
   end
 end
 

--- a/rspec_junit_formatter.gemspec
+++ b/rspec_junit_formatter.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.16"
   s.add_development_dependency "nokogiri", "~> 1.6"
   s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "coderay", "~> 1.0"
 
   s.files        = Dir["lib/**/*", "README.md", "LICENSE"]
   s.require_path = "lib"

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -122,7 +122,7 @@ describe RspecJunitFormatter do
   context "when $TEST_ENV_NUMBER is set" do
     around do |example|
       begin
-        ENV["TEST_ENV_NUMBER"] = "2"
+        ENV["TEST_ENV_NUMBER"] = "42"
         example.call
       ensure
         ENV.delete("TEST_ENV_NUMBER")
@@ -130,7 +130,7 @@ describe RspecJunitFormatter do
     end
 
     it "includes $TEST_ENV_NUMBER in the testsuite name" do
-      expect(testsuite["name"]).to eql("rspec2")
+      expect(testsuite["name"]).to eql("rspec42")
     end
   end
 


### PR DESCRIPTION
@sj26  followup to #54
- update tests to ensure there is no colorized output
  - added `coderay` to the gemspec
  - used `PTY.spawn` instead of `IO.popen` to emulate a terminal
- added rspec 3.7 to travis
- use `respond_to?` instead of the rspec version in `without_color` for future proofing
- remove color codes from rspec 2.x diffs (bug exposed by new test case)