### PR TITLE
Fix #strip_diff_colors output for CircleCI

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -150,8 +150,8 @@ private
     text.to_s.encode(Encoding::UTF_8).gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT).gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
   end
 
-  STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: (?: \e\[0m )? (?: \n \1 \e\[\d+m .* )* /x
-  STRIP_DIFF_COLORS_CODES_REGEXP = /\e\[\d+m/
+  STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: (?: \e\[0m )? (?: \n \1 \e\[(\d+;?){1,3}m .* )* /x
+  STRIP_DIFF_COLORS_CODES_REGEXP = /\e\[(\d+;?){1,3}m/
 
   def strip_diff_colors(string)
     # XXX: RSpec diffs are appended to the message lines fairly early and will


### PR DESCRIPTION
Hello,

small regex improvement for stripping out colored text, you can see how it works before and after the change:

before:
![before](https://user-images.githubusercontent.com/235847/40509967-7268c732-5f9b-11e8-83f5-66fed7aa1ae5.png)

after:
![after](https://user-images.githubusercontent.com/235847/40509980-79959a94-5f9b-11e8-9ca3-86ff178f4f4b.png)

hope that helps 