### PR TITLE
[FEATURE] Show line number in file path

### DIFF
--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -22,7 +22,7 @@ private
     while meta[:example_group]
       meta = meta[:example_group]
     end
-    meta[:file_path]
+    meta[:location]
   end
 
   def classname_for(example)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -52,7 +52,7 @@ private
     while parent_metadata = metadata[:parent_example_group]
       metadata = parent_metadata
     end
-    metadata[:file_path]
+    metadata[:location]
   end
 
   def classname_for(notification)

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -120,6 +120,7 @@ describe RspecJunitFormatter do
     shared_testcases.each do |testcase|
       # shared examples should be groups with their including files
       expect(testcase["classname"]).to eql("spec.example_spec")
+      expect(testcase["file"]).to eql("./spec/example_spec.rb:4")
     end
 
     expect(failed_shared_testcases.size).to eql(1)


### PR DESCRIPTION
Shows the line number in the file path
```xml
<testcase 
  classname="spec.commands.speccy_the_spectacle"
  name="Thing::Guy#call should be successful"
  file="./spec/commands/speccy_the_spectacle.rb:5"
  time="0.381122">
</testcase>
```

This is really helpful because it means I can literally take the failed example and paste directly into my CLI to run the test, rather than hunting down for the actual example that failed within the file