### PR TITLE
fix: harden encoding of output text

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -160,9 +160,15 @@ private
     ?>.freeze => "&gt;".freeze,
   ).freeze
 
+  def encode(text)
+    text.to_s.encode(Encoding::UTF_8)
+  rescue Encoding::UndefinedConversionError
+    text.force_encoding(Encoding::UTF_8)
+  end
+
   def escape(text)
     # Make sure it's utf-8, replace illegal characters with ruby-like escapes, and replace special and discouraged characters with entities
-    text.to_s.encode(Encoding::UTF_8).gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT).gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
+    encode(text).gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT).gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
   end
 
   STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: (?: \e\[ 0 m )? (?: \n \1 \e\[ \d+ (?: ; \d+ )* m .* )* /x


### PR DESCRIPTION
After upgrading from v0.3.0 to v0.4.1 we experienced issues when using `rspec_junit_formatter` together with `serverspec`. Text that was originally encoded in UTF-8 was treated as ASCII and when trying to be encoded in UTF-8 as part of the `escape` method gave the following error

```
Traceback (most recent call last):
	23: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/exe/rspec:4:in `<main>'
	22: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:45:in `invoke'
	21: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:71:in `run'
	20: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:87:in `run'
	19: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:112:in `run_specs'
	18: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:81:in `report'
	17: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:171:in `finish'
	16: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:191:in `close_after'
	15: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:182:in `block in finish'
	14: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:205:in `notify'
	13: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:205:in `each'
	12: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:206:in `block in notify'
	11: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter/rspec3.rb:19:in `dump_summary'
	10: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter/rspec3.rb:113:in `without_color'
	 9: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter/rspec3.rb:100:in `swap_rspec_configuration'
	 8: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter/rspec3.rb:19:in `block in dump_summary'
	 7: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:32:in `xml_dump'
	 6: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:37:in `xml_dump_examples'
	 5: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:37:in `each'
	 4: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:44:in `block in xml_dump_examples'
	 3: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:74:in `xml_dump_example'
	 2: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:83:in `xml_dump_output'
	 1: from /usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:167:in `escape'
/usr/local/lib/ruby/gems/2.5.0/gems/rspec_junit_formatter-0.4.1/lib/rspec_junit_formatter.rb:167:in `encode': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
rake aborted!
NoMethodError: undefined method `match' for nil:NilClass
[..]
(See full trace by running task with --trace)
```

After a bit of research I stumbled on the following issue JoshCheek/seeing_is_believing#46. While the root cause is different, the `#force_encoding` solved my issue, since I so far couldn't determine the exact point in my setup were the encoding was messed up.

I'm not 100% sure if this should be included here, but it solved our issue so I wanted to at least share it.