### PR TITLE
Add line number and scoped id to output

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -67,7 +67,13 @@ private
     output << %{<testcase}
     output << %{ classname="#{escape(classname_for(example))}"}
     output << %{ name="#{escape(description_for(example))}"}
-    output << %{ file="#{escape(example_group_file_path_for(example))}"}
+    output << %{ file="#{escape(file_path_for(example) || example_group_file_path_for(example))}"}
+    if line_number = line_number_for(example)
+      output << %{ line="#{escape(line_number.to_s)}"}
+    end
+    if scoped_id = scoped_id_for(example)
+      output << %{ scoped-id="#{escape(scoped_id)}"}
+    end
     output << %{ time="#{escape("%.6f" % duration_for(example))}"}
     output << %{>}
     yield if block_given?

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -25,6 +25,18 @@ private
     meta[:file_path]
   end
 
+  def file_path_for(notification)
+    nil
+  end
+
+  def line_number_for(notification)
+    nil
+  end
+
+  def scoped_id_for(notification)
+    nil
+  end
+
   def classname_for(example)
     fp = example_group_file_path_for(example)
     fp.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -55,6 +55,18 @@ private
     metadata[:file_path]
   end
 
+  def file_path_for(notification)
+    notification.example.metadata[:file_path]
+  end
+
+  def line_number_for(notification)
+    notification.example.metadata[:line_number]
+  end
+
+  def scoped_id_for(notification)
+    notification.example.metadata[:scoped_id]
+  end
+
   def classname_for(notification)
     fp = example_group_file_path_for(notification)
     fp.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")


### PR DESCRIPTION
This is useful for matching up tests results in different configurations (e.g. we have ~200 configurations we test the Ruby MongoDB driver with) for analysis purposes.