### PR TITLE
Add `line_number` to XML output

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -68,6 +68,7 @@ private
     output << %{ classname="#{escape(classname_for(example))}"}
     output << %{ name="#{escape(description_for(example))}"}
     output << %{ file="#{escape(example_group_file_path_for(example))}"}
+    output << %{ line_number="#{escape(line_number_for(example))}"}
     output << %{ time="#{escape("%.6f" % duration_for(example))}"}
     output << %{>}
     yield if block_given?

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -25,6 +25,14 @@ private
     meta[:file_path]
   end
 
+  def line_number_for(example)
+    meta = example.metadata
+    while meta[:example_group]
+      meta = meta[:example_group]
+    end
+    meta[:line_number]
+  end
+
   def classname_for(example)
     fp = example_group_file_path_for(example)
     fp.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -55,6 +55,10 @@ private
     metadata[:file_path]
   end
 
+  def line_number_for(notification)
+    notification.example.metadata[:line_number]
+  end
+
   def classname_for(notification)
     fp = example_group_file_path_for(notification)
     fp.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -71,6 +71,7 @@ describe RspecJunitFormatter do
 
     testcases.each do |testcase|
       expect(testcase["classname"]).to eql("spec.example_spec")
+      expect(testcase["file"]).not_to be_empty
       expect(testcase["name"]).not_to be_empty
       expect(testcase["time"].to_f).to be > 0
     end
@@ -108,6 +109,7 @@ describe RspecJunitFormatter do
       expect(testcase.element_children.size).to eql(1)
 
       child = testcase.element_children.first
+      expect(testcase["file"]).not_to be_empty
       expect(child.name).to eql("failure")
       expect(child["message"]).not_to be_empty
       expect(child.text.strip).not_to be_empty

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -72,6 +72,7 @@ describe RspecJunitFormatter do
     testcases.each do |testcase|
       expect(testcase["classname"]).to eql("spec.example_spec")
       expect(testcase["file"]).not_to be_empty
+      expect(testcase["line_number"].to_i).to be > 0
       expect(testcase["name"]).not_to be_empty
       expect(testcase["time"].to_f).to be > 0
     end
@@ -110,6 +111,7 @@ describe RspecJunitFormatter do
 
       child = testcase.element_children.first
       expect(testcase["file"]).not_to be_empty
+      expect(testcase["line_number"].to_i).to be > 0
       expect(child.name).to eql("failure")
       expect(child["message"]).not_to be_empty
       expect(child.text.strip).not_to be_empty


### PR DESCRIPTION
# Motivation

I want to split my tests by individual test timings.

# Changes

Ensures `line_number` is present in the XML result for each test.

# Concerns

1. Should the tests assert for specific line numbers? 
2. Are shared examples captured correctly?