### PR TITLE
Update invalid testcase attribute file

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -67,7 +67,7 @@ private
     output << %{<testcase}
     output << %{ classname="#{escape(classname_for(example))}"}
     output << %{ name="#{escape(description_for(example))}"}
-    output << %{ file="#{escape(example_group_file_path_for(example))}"}
+    output << %{ filename="#{escape(example_group_file_path_for(example))}"}
     output << %{ time="#{escape("%.6f" % duration_for(example))}"}
     output << %{>}
     yield if block_given?


### PR DESCRIPTION
I'm seeing this in my test pipeline with an updated (> 2.0) version of xunit:
```
Attribute 'file' is not allowed to appear in element 'testcase'.
```

I cannot find any documentation on what the xml should be, so this PR is a wild guess. Alternatively, I could remove the attribute entirely.

Issue: https://github.com/sj26/rspec_junit_formatter/issues/65