### PR TITLE
Show detail for failing examples using aggregate_failures

### DIFF
--- a/example/spec/example_spec.rb
+++ b/example/spec/example_spec.rb
@@ -22,6 +22,11 @@ describe "some example specs" do
     end
   end
 
+  it "should support multiple failures", aggregate_failures: true do
+    expect('foo').to eq 1
+    expect('bar').to eq 2
+  end
+
   it "shows diffs cleanly" do
     expect({a: "b", c: "d"}).to eql({a: 2, c: 4})
   end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -77,7 +77,20 @@ private
   end
 
   def failure_for(notification)
-    lines = notification.message_lines + [''] + notification.formatted_backtrace
+    lines = notification.fully_formatted_lines(nil, RSpec::Core::Notifications::NullColorizer).map(&:to_s)
+
+    unless lines.first.empty?
+      raise 'Expected first line to be empty'
+    end
+    lines.shift
+
+    indentation = lines.reject(&:empty?).map { |line| line[/^[ \t]*/] }.min
+    lines = lines.map { |line| line.sub(/^#{Regexp.escape indentation}/, '') }
+
+    unless lines.first == notification.description
+      raise 'Expected second line to be description'
+    end
+    lines.shift
 
     strip_diff_colors(lines.join("\n"))
   end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -77,7 +77,9 @@ private
   end
 
   def failure_for(notification)
-    strip_diff_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
+    lines = notification.message_lines + [''] + notification.formatted_backtrace
+
+    strip_diff_colors(lines.join("\n"))
   end
 
   def exception_for(notification)

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -46,6 +46,7 @@ describe RspecJunitFormatter do
   let(:failed_testcases) { doc.xpath("/testsuite/testcase[failure]") }
   let(:shared_testcases) { doc.xpath("/testsuite/testcase[contains(@name, 'shared example')]") }
   let(:failed_shared_testcases) { doc.xpath("/testsuite/testcase[contains(@name, 'shared example')][failure]") }
+  let(:failed_multiple_testcases) { doc.xpath("/testsuite/testcase[contains(@name, 'multiple')][failure]") }
 
   # Combined into a single example so we don't have to re-run the example rspec
   # process over and over. (We need to change the parameters in later specs so
@@ -57,9 +58,9 @@ describe RspecJunitFormatter do
     expect(testsuite).not_to be(nil)
 
     expect(testsuite["name"]).to eql("rspec")
-    expect(testsuite["tests"]).to eql("12")
+    expect(testsuite["tests"]).to eql("13")
     expect(testsuite["skipped"]).to eql("1")
-    expect(testsuite["failures"]).to eql("8")
+    expect(testsuite["failures"]).to eql("9")
     expect(testsuite["errors"]).to eql("0")
     expect(Time.parse(testsuite["timestamp"])).to be_within(60).of(Time.now)
     expect(testsuite["time"].to_f).to be > 0
@@ -67,7 +68,7 @@ describe RspecJunitFormatter do
 
     # it has some test cases
 
-    expect(testcases.size).to eql(12)
+    expect(testcases.size).to eql(13)
 
     testcases.each do |testcase|
       expect(testcase["classname"]).to eql("spec.example_spec")
@@ -101,7 +102,7 @@ describe RspecJunitFormatter do
 
     # it has failed test cases
 
-    expect(failed_testcases.size).to eql(8)
+    expect(failed_testcases.size).to eql(9)
 
     failed_testcases.each do |testcase|
       expect(testcase).not_to be(nil)
@@ -126,6 +127,13 @@ describe RspecJunitFormatter do
     failed_shared_testcases.each do |testcase|
       expect(testcase.text).to include("example_spec.rb")
       expect(testcase.text).to include("shared_examples.rb")
+    end
+
+    # it has detail for an aggregate_failures example
+    expect(failed_multiple_testcases.size).to eql(1)
+    failed_multiple_testcases.each do |testcase|
+      expect(testcase.text).to include("foo")
+      expect(testcase.text).to include("bar")
     end
 
     # it cleans up diffs


### PR DESCRIPTION
## Example

### Before
<img width="512" height="141" alt="" src="https://user-images.githubusercontent.com/83466/67066554-6a396900-f1b6-11e9-87ce-91fe5269f3bd.png">

### After
<img width="511" height="515" alt="" src="https://user-images.githubusercontent.com/83466/67066556-6b6a9600-f1b6-11e9-8276-a36f9b96f92d.png">

## Note

There is a minor change to how backtraces are formatted. It’s now the same as what `rspec` shows when ran from directly:

### Before
<img width="512" alt="" height="165" src="https://user-images.githubusercontent.com/83466/67066687-f6e42700-f1b6-11e9-9603-3b64bae98cdb.png">

### After
<img width="512" alt="" height="167" src="https://user-images.githubusercontent.com/83466/67066688-f8155400-f1b6-11e9-88e6-d0b6fc019d68.png">
