### PR TITLE
Force convert all the diff content to UTF-8

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -180,7 +180,7 @@ private
     # We also only want to target the diff hunks because the failure message
     # itself might legitimately contain ansi escape codes.
     #
-    string.sub(STRIP_DIFF_COLORS_BLOCK_REGEXP) { |match| match.gsub(STRIP_DIFF_COLORS_CODES_REGEXP, "".freeze) }
+    string.encode('UTF-8', 'UTF-8', invalid: :replace).sub(STRIP_DIFF_COLORS_BLOCK_REGEXP) { |match| match.gsub(STRIP_DIFF_COLORS_CODES_REGEXP, "".freeze) }
   end
 end
 


### PR DESCRIPTION
Force convert all the diff content to UTF-8

## What
We are facing exception:
```
/bundle/ruby/2.6.0/bundler/gems/rspec_junit_formatter-1129bf0d5fb4/lib/rspec_junit_formatter.rb:186:in `sub': invalid byte sequence in UTF-8 (ArgumentError)
```

## Why
One of the diff string contains invalid UTF-8 characters.
E.g. `string = "784: unexpected token at '\u001F\x8B\b'"`
Then if you run `string.sub('xxx', 'xxx')` you will see the same exception be raised.

## Solution
Force encode string to UTF-8 encoding at the beginning.