### PR TITLE
Skip STDOUT/STDERR capture when reports are not generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,22 @@ If you like, you can capture the standard output and error streams of each test 
 # spec_helper.rb
 
 RSpec.configure do |config|
-  # register around filter that captures stdout and stderr
-  config.around(:each) do |example|
-    $stdout = StringIO.new
-    $stderr = StringIO.new
+  # Reassigning stdout/stderr has consequences, e.g. invocations of the pry debugger will be ignored. 
+  # So only capture STDOUT/STDERR if this plugin is actually being used
+  if RSpec::Core::ConfigurationOptions.new(ARGV).options[:formatters].any? { |s| s.first == "RspecJunitFormatter" }
+    # register around filter that captures stdout and stderr
+    config.around(:each) do |example|
+      $stdout = StringIO.new
+      $stderr = StringIO.new
 
-    example.run
+      example.run
 
-    example.metadata[:stdout] = $stdout.string
-    example.metadata[:stderr] = $stderr.string
+      example.metadata[:stdout] = $stdout.string
+      example.metadata[:stderr] = $stderr.string
 
-    $stdout = STDOUT
-    $stderr = STDERR
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
   end
 end
 ```


### PR DESCRIPTION
Using the example `config.around(:each)` behavior listed here has a strange side effect with tools like `pry` (and possibly others) in which invoking `binding.pry` seems to simply be ignored.  This is probably to do with `pry`'s expectation of working with a terminal and finding none.   

But in any case, this code checks whether the `RspecJunitFormatter` has been requested and captures output conditionally on that setting.