### PR TITLE
[Feature] Add attachment tag screenshot for failing tests

### DIFF
--- a/example/spec/example_spec.rb
+++ b/example/spec/example_spec.rb
@@ -48,4 +48,8 @@ describe "some example specs" do
     $stdout.puts "Test"
     $stderr.puts "Bar"
   end
+
+  it "includes an attachment tag", has_screenshots: true do
+    expect("attachment").to eql("screenshots")
+  end
 end

--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -9,6 +9,14 @@ RSpec.configure do |config|
     example.metadata[:stdout] = $stdout.string
     example.metadata[:stderr] = $stderr.string
 
+    # register screenshots if failing test attached to it
+    if example.metadata[:has_screenshots]
+      example.metadata[:screenshot] = {
+        html: "tmp/some/path.html",
+        image: "tmp/some/path.png"
+      }
+    end
+
     $stdout = STDOUT
     $stderr = STDERR
   end

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -73,6 +73,7 @@ private
     output << %{ time="#{escape("%.6f" % duration_for(example))}"}
     output << %{>}
     yield if block_given?
+    xml_dump_attachment(example) if screenshot_exists?(example)
     xml_dump_output(example)
     output << %{</testcase>\n}
   end
@@ -89,6 +90,12 @@ private
       output << escape(stderr)
       output << %{</system-err>}
     end
+  end
+
+  def xml_dump_attachment(example)
+    output << %{\n<system-out>}
+    output << %{[[ATTACHMENT|#{escape(screenshot_for(example))}]]}
+    output << %{</system-out>\n}
   end
 
   # Inversion of character range from https://www.w3.org/TR/xml/#charsets

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -79,4 +79,20 @@ private
   def stderr_for(example)
     example.metadata[:stderr]
   end
+
+  def screenshot_exists?(example)
+    !!example.metadata[:screenshot]
+  end
+
+  def html_screenshot_for(example)
+    example.metadata[:screenshot][:html]
+  end
+
+  def image_screenshot_for(example)
+    example.metadata[:screenshot][:image]
+  end
+
+  def screenshot_for(example)
+    image_screenshot_for(example) || html_screenshot_for(example)
+  end
 end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -132,6 +132,22 @@ private
   def stderr_for(example_notification)
     example_notification.example.metadata[:stderr]
   end
+
+  def screenshot_exists?(example_notification)
+    !!example_notification.example.metadata[:screenshot]
+  end
+
+  def html_screenshot_for(example_notification)
+    example_notification.example.metadata[:screenshot][:html]
+  end
+
+  def image_screenshot_for(example_notification)
+    example_notification.example.metadata[:screenshot][:image]
+  end
+
+  def screenshot_for(example_notification)
+    image_screenshot_for(example_notification) || html_screenshot_for(example_notification)
+  end
 end
 
 # rspec-core 3.0.x forgot to mark this as a module function which causes:


### PR DESCRIPTION
## What does this PR do?

This PR implements the same feature that this [jenkins plugin](https://plugins.jenkins.io/junit-attachments) does by archiving certain files (attachments) together with JUnit results.

It adds a **new attachment tag** for a specific test case:

```xml
<system-out>[[ATTACHMENT|tmp/capybara/screenshot_return-hello-world.html]]</system-out>
```

## Why do we need this?
It seems common that certain folks want to be able to link failed screenshots for a given test to their `JUnit` reports.

This PR makes it possible for ruby folks to map their failing test with screenshots taken by capybara.

### Before
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="0.017918" timestamp="2020-03-09T15:40:26-04:00" hostname="Maximes-MacBook-Pro.local">
<properties>
<property name="seed" value="4000"/>
</properties>
<testcase classname="spec.hello_world_spec" name="the home page return hello world" file="./spec/hello_world_spec.rb" time="0.016554"><failure message="" type="RuntimeError">Failure/Error: raise
RuntimeError:
./spec/hello_world_spec.rb:8:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure></testcase>
</testsuite>
```

### After
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="0.017557" timestamp="2020-03-09T15:16:55-04:00" hostname="Maximes-MacBook-Pro.local">
<properties>
<property name="seed" value="9386"/>
</properties>
<testcase classname="spec.hello_world_spec" name="the home page return hello world" file="./spec/hello_world_spec.rb" time="0.016340"><failure message="" type="RuntimeError">Failure/Error: raise
RuntimeError:
./spec/hello_world_spec.rb:8:in `block (2 levels) in &lt;top (required)&gt;&apos;</failure>
<system-out>[[ATTACHMENT|tmp/capybara/screenshot_return-hello-world.html]]</system-out>
</testcase>
</testsuite>
```

Inspired by how https://github.com/sj26/rspec_junit_formatter/pull/53  was implemented

cc @sj26 what do you think of this PR ? Could you give it a review 🙏 