### PR TITLE
Added support to read outside error count returned from XML formatter.

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -20,7 +20,7 @@ private
     output << %{ tests="#{example_count}"}
     output << %{ skipped="#{pending_count}"}
     output << %{ failures="#{failure_count}"}
-    output << %{ errors="0"}
+    output << %{ errors="#{error_count}"}
     output << %{ time="#{escape("%.6f" % duration)}"}
     output << %{ timestamp="#{escape(started.iso8601)}"}
     output << %{ hostname="#{escape(Socket.gethostname)}"}

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -64,6 +64,10 @@ private
     "#{message}\n#{backtrace.join("\n")}"
   end
 
+  def error_count
+    0
+  end
+
   def find_shared_group(example)
     group_and_parent_groups(example).find { |group| group.metadata[:shared_group_name] }
   end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -46,7 +46,12 @@ private
   end
 
   def error_count
-    reports_errors_outside? ? @summary_notification.errors_outside_of_examples_count : 0
+    # Introduced in rspec 3.6
+    if @summary_notification.respond_to?(:errors_outside_of_examples_count)
+      @summary_notification.errors_outside_of_examples_count
+    else
+      0
+    end
   end
 
   def result_of(notification)
@@ -127,10 +132,6 @@ private
     def without_color
       yield
     end
-  end
-
-  def reports_errors_outside?
-    Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.6")
   end
 
   def stdout_for(example_notification)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -45,6 +45,10 @@ private
     @examples_notification.notifications
   end
 
+  def error_count
+    reports_errors_outside? ? @summary_notification.errors_outside_of_examples_count : 0
+  end
+
   def result_of(notification)
     notification.example.execution_result.status
   end
@@ -123,6 +127,10 @@ private
     def without_color
       yield
     end
+  end
+
+  def reports_errors_outside?
+    Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.6")
   end
 
   def stdout_for(example_notification)


### PR DESCRIPTION
I opened a issue #85 to get error count from errors outside of an example.  This is the pull request for that issue.  Please let me know if there is any further action needed.