### PR TITLE
CI: Add 2.7 to matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4


### PR DESCRIPTION
This PR adds 2.7 to the matrix.

Remove unused sudo: false Travis directive
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).