### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/rspec_junit_formatter.gemspec
+++ b/rspec_junit_formatter.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.author      = "Samuel Cochran"
   s.email       = "sj26@sj26.com"
-  s.homepage    = "http://github.com/sj26/rspec_junit_formatter"
+  s.homepage    = "https://github.com/sj26/rspec_junit_formatter"
   s.summary     = "RSpec JUnit XML formatter"
   s.description = "RSpec results that your continuous integration service can read."
   s.license     = "MIT"


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/rspec_junit_formatter or some tools or APIs that use the gem's metadata.