### PR TITLE
Add support for optional path prefix for testcase file property

### DIFF
--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 RSpec.configure do |config|
+  if ENV["JUNIT_FORMATTER_FILE_PATH_PREFIX"]
+    config.junit_formatter_file_path_prefix = ENV["JUNIT_FORMATTER_FILE_PATH_PREFIX"]
+  end
+
   # register around filter that captures stderr and stdout
   config.around(:each) do |example|
     $stdout = StringIO.new

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -6,6 +6,8 @@ require "time"
 require "rspec/core"
 require "rspec/core/formatters/base_formatter"
 
+::RSpec.configuration.add_setting :junit_formatter_file_path_prefix
+
 # Dumps rspec results as a JUnit XML file.
 # Based on XML schema: http://windyroad.org/dl/Open%20Source/JUnit.xsd
 class RSpecJUnitFormatter < RSpec::Core::Formatters::BaseFormatter

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -24,7 +24,12 @@ private
     while meta[:example_group]
       meta = meta[:example_group]
     end
-    meta[:file_path]
+
+    if RSpec.configuration.junit_formatter_file_path_prefix?
+      Pathname.new(RSpec.configuration.junit_formatter_file_path_prefix).join(meta[:file_path]).to_s
+    else
+      meta[:file_path]
+    end
   end
 
   def classname_for(example)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -63,7 +63,12 @@ private
     while parent_metadata = metadata[:parent_example_group]
       metadata = parent_metadata
     end
-    metadata[:file_path]
+
+    if RSpec.configuration.junit_formatter_file_path_prefix?
+      Pathname.new(RSpec.configuration.junit_formatter_file_path_prefix).join(metadata[:file_path]).to_s
+    else
+      metadata[:file_path]
+    end
   end
 
   def classname_for(notification)

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -187,4 +187,22 @@ describe RspecJunitFormatter do
       expect(seed_property["value"]).to eql("12345")
     end
   end
+
+  context "when a junit_formatter_file_path_prefix is set" do
+    around do |example|
+      begin
+        ENV["JUNIT_FORMATTER_FILE_PATH_PREFIX"] = "some/prefix"
+        example.call
+      ensure
+        ENV.delete("JUNIT_FORMATTER_FILE_PATH_PREFIX")
+      end
+    end
+
+    it "prepends the prefix to each file path" do
+      expect(testcases).not_to be_empty
+      testcases.each do |testcase|
+        expect(testcase["file"]).to eql("some/prefix/spec/example_spec.rb")
+      end
+    end
+  end
 end

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -77,6 +77,7 @@ describe RspecJunitFormatter do
 
     testcases.each do |testcase|
       expect(testcase["classname"]).to eql("spec.example_spec")
+      expect(testcase["file"]).to eql("./spec/example_spec.rb")
       expect(testcase["name"]).not_to be_empty
       expect(testcase["time"].to_f).to be > 0
     end


### PR DESCRIPTION
Currently, the `file` property of each `testcase` element contains the path to the file from RSpec's perspective, but that's not always the full path to the file from the root of the repository. For example, in [Homebrew/brew](https://github.com/Homebrew/brew), consider the `testcase` element emitted for a test in [`Library/Homebrew/test/dev-cmd/bump_spec.rb`](https://github.com/Homebrew/brew/blob/3.2.3/Library/Homebrew/test/dev-cmd/bump_spec.rb):

```
<testcase 
  classname="test.dev-cmd.bump_spec"
  name="brew bump behaves like parseable arguments can parse arguments"
  file="./test/dev-cmd/bump_spec.rb"
  time="0.015492">
</testcase>
```

The `file` property points to `./test/dev-cmd/bump_spec.rb`, but the file actually resides at [`Library/Homebrew/test/dev-cmd/bump_spec.rb`](https://github.com/Homebrew/brew/blob/3.2.3/Library/Homebrew/test/dev-cmd/bump_spec.rb). Currently, rspec_junit_formatter has no way to know this full path to the file, so this pull request proposes a way to make that information available to rspec_junit_formatter. 😅

For tooling that consumes the XML emitted by rspec_junit_formatter, it's useful to be able to use the `file` property as the full path to the file from the root of the repository, so that the tooling can link to file on github.com (or wherever the repository is hosted).

This pull request proposes adding an optional setting for specifying a path prefix. For example, Homebrew/brew would set this as follows:

```rb
RSpec.configure do |config|
  config.junit_formatter_file_path_prefix = "Library/Homebrew"
end
```

And instead of file property being `./test/dev-cmd/bump_spec.rb`, it would be `Library/Homebrew/test/dev-cmd/bump_spec.rb`.

What do you think?

---

Note: This is my first time proposing functionality for an RSpec formatter. I see that [fuubar uses custom RSpec settings for its configuration](https://github.com/thekompanee/fuubar/blob/releases/2.5.1/lib/fuubar.rb#L8), so this pull request uses that same approach. If there's a different approach that would work better for rspec_junit_formatter, please let me know, and I'll update the implementation accordingly.