### PR TITLE
Add `require: false` to Gemfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add it to your Gemfile if you're using [Bundler][bundler]. Put it in the same gr
 ```ruby
 group :test do
   gem "rspec"
-  gem "rspec_junit_formatter"
+  gem "rspec_junit_formatter", require: false
 end
 ```
 


### PR DESCRIPTION
RSpec has the ability to automatically load custom formatter that follows the naming conventions properly, so there is no need to have `Bundler.require` load it for you.

Adding this `require: false` makes it more profitable to have it loaded only when needed (e.g. only in CI if you use this formatter only in CI).

I don't think many people want to output JUnit format files locally, so it will cut down on unnecessary loading in many cases. Also, this README Gemfile example is probably close to the example used in a typical Rails app, so many Rails users will benefit from this.

This change also eliminates another problem. If you run `require 'rspec/core'` before the appropriate time, `Kernel.#context` will be defined and you will get a warning when you load irb. The following Issue provides more information on this issue.

- https://github.com/rspec/rspec-rails/issues/1645

Since rspec_junit_formatter executes `require 'rspec/core'` when loaded, it causes this problem when loaded with `Bundler.require`. This `require: false` also resolves this problem.

- https://github.com/sj26/rspec_junit_formatter/blob/02c1756f2b50853ccf698cca7ab2d607f67b47b3/lib/rspec_junit_formatter.rb#L6

```
$ bin/rails c -e test
Loading test environment (Rails 7.0.4)
irb: warn: can't alias context from irb_context.
irb(main):001:0> exit
````