### PR TITLE
Replace invalid characters with a placeholder

### DIFF
--- a/example/spec/example_spec.rb
+++ b/example/spec/example_spec.rb
@@ -26,7 +26,7 @@ describe "some example specs" do
     expect({a: "b", c: "d"}).to eql({a: 2, c: 4})
   end
 
-  it "replaces naughty \0 and \e characters, \x01 and \uFFFF too" do
+  it "replaces naughty \0 and \e characters, \x01 and \uFFFF too, and \xF0" do
     expect("\0\0\0").to eql("emergency services")
   end
 

--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -166,7 +166,7 @@ private
 
   def escape(text)
     # Make sure it's utf-8, replace illegal characters with ruby-like escapes, and replace special and discouraged characters with entities
-    text.to_s.encode(Encoding::UTF_8).gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT).gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
+    text.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '??invalid??').gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT).gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
   end
 
   STRIP_DIFF_COLORS_BLOCK_REGEXP = /^ ( [ ]* ) Diff: (?: \e\[ 0 m )? (?: \n \1 \e\[ \d+ (?: ; \d+ )* m .* )* /x

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -142,7 +142,7 @@ describe RspecJunitFormatter do
 
     # it correctly replaces illegal characters
 
-    expect(doc.xpath("//testcase[contains(@name, 'naughty')]").first[:name]).to eql("some example specs replaces naughty \\0 and \\e characters, \\x01 and \\uFFFF too")
+    expect(doc.xpath("//testcase[contains(@name, 'naughty')]").first[:name]).to eql("some example specs replaces naughty \\0 and \\e characters, \\x01 and \\uFFFF too, and ??invalid??")
 
     # it correctly escapes discouraged characters
 


### PR DESCRIPTION
It seems that when tests print an emoji in the failure reason rspec_junit_formatter fails and prints the xml its already generated to that point which ends up being invalid because it creates an xml element with a missing closing brackets and that cannot be parsed by the tools that attempt to read it.

This fix causes invalid characters to be replaced with ??invalid?? instead of bailing out immediately. rspec_junit_formatter shouldn't output invalid xml regardless of the failures it encounters along the way.

This should fix this issue: https://github.com/sj26/rspec_junit_formatter/issues/92