### PR TITLE
show details for failing examples tagged with `aggregate_failures: true`

### DIFF
--- a/example/spec/example_spec.rb
+++ b/example/spec/example_spec.rb
@@ -48,4 +48,9 @@ describe "some example specs" do
     $stdout.puts "Test"
     $stderr.puts "Bar"
   end
+
+  it "should support multiple failures", aggregate_failures: true do
+    expect('foo').to eq 1
+    expect('bar').to eq 2
+  end
 end

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -88,7 +88,12 @@ private
   end
 
   def failure_for(notification)
-    strip_diff_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
+    exception = exception_for(notification)
+    if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError)
+      strip_diff_colors(exception.message)
+    else
+      strip_diff_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
+    end
   end
 
   def exception_for(notification)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -89,7 +89,8 @@ private
 
   def failure_for(notification)
     exception = exception_for(notification)
-    if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError)
+
+    if aggregate_failure?(exception)
       strip_diff_colors(exception.message)
     else
       strip_diff_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
@@ -145,6 +146,13 @@ private
 
   def stderr_for(example_notification)
     example_notification.example.metadata[:stderr]
+  end
+
+  def aggregate_failure?(exception)
+    # Introduced in rspec 3.3
+    return false unless defined?(RSpec::Expectations::MultipleExpectationsNotMetError)
+
+    exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError)
   end
 end
 

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -52,6 +52,7 @@ describe RspecJunitFormatter do
   let(:failed_testcases) { doc.xpath("/testsuite/testcase[failure]") }
   let(:shared_testcases) { doc.xpath("/testsuite/testcase[contains(@name, 'shared example')]") }
   let(:failed_shared_testcases) { doc.xpath("/testsuite/testcase[contains(@name, 'shared example')][failure]") }
+  let(:failed_multiple_testcases) { doc.xpath("/testsuite/testcase[contains(@name, 'multiple')][failure]") }
 
   # Combined into a single example so we don't have to re-run the example rspec
   # process over and over. (We need to change the parameters in later specs so
@@ -63,9 +64,9 @@ describe RspecJunitFormatter do
     expect(testsuite).not_to be(nil)
 
     expect(testsuite["name"]).to eql("rspec")
-    expect(testsuite["tests"]).to eql("12")
+    expect(testsuite["tests"]).to eql("13")
     expect(testsuite["skipped"]).to eql("1")
-    expect(testsuite["failures"]).to eql("8")
+    expect(testsuite["failures"]).to eql("9")
     expect(testsuite["errors"]).to eql("0")
     expect(Time.parse(testsuite["timestamp"])).to be_within(60).of(Time.now)
     expect(testsuite["time"].to_f).to be > 0
@@ -73,7 +74,7 @@ describe RspecJunitFormatter do
 
     # it has some test cases
 
-    expect(testcases.size).to eql(12)
+    expect(testcases.size).to eql(13)
 
     testcases.each do |testcase|
       expect(testcase["classname"]).to eql("spec.example_spec")
@@ -107,7 +108,7 @@ describe RspecJunitFormatter do
 
     # it has failed test cases
 
-    expect(failed_testcases.size).to eql(8)
+    expect(failed_testcases.size).to eql(9)
 
     failed_testcases.each do |testcase|
       expect(testcase).not_to be(nil)
@@ -132,6 +133,17 @@ describe RspecJunitFormatter do
     failed_shared_testcases.each do |testcase|
       expect(testcase.text).to include("example_spec.rb")
       expect(testcase.text).to include("shared_examples.rb")
+    end
+
+    # it has detail for an aggregate_failures example
+    expect(failed_multiple_testcases.size).to eql(1)
+    failed_multiple_testcases.each do |testcase|
+      expect(testcase.text).to include("foo")
+      if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new('3.3')
+        expect(testcase.text).to include("bar")
+      else
+        expect(testcase.text).to_not include("bar")
+      end
     end
 
     # it cleans up diffs


### PR DESCRIPTION
This will fix Issue #56 and was heavily inspired by #74 and all credit for the specs go to  @jasoncodes

It outputs the `exception.message` in the case of a `RSpec::Expectations::MultipleExpectationsNotMetError`. This emulates what `Core::Formatters::JsonFormatter` does: https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/formatters/json_formatter.rb#L43

**Before**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="0.014878" timestamp="2024-09-10T10:30:24+02:00" hostname="GREM-C02C90V3MD6V.local">
     <properties>
          <property name="seed" value="12345"/>
     </properties>
     <testcase classname="spec.example_spec" name="some example specs should support multiple failures" file="./spec/example_spec.rb" time="0.013631"><failure message="RSpec::Expectations::MultipleExpectationsNotMetError" type="RSpec::Expectations::MultipleExpectationsNotMetError">
     </failure></testcase>
</testsuite>
```

**After**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite errors="0" failures="1" hostname="GREM-C02C90V3MD6V.local" name="rspec" skipped="0" tests="1" time="0.010382" timestamp="2024-09-10T10:31:22+02:00">
     <properties>
          <property name="seed" value="12345"/>
     </properties>
     <testcase classname="spec.example_spec" file="./spec/example_spec.rb" name="some example specs should support multiple failures" time="0.009463">
          <failure message="RSpec::Expectations::MultipleExpectationsNotMetError" type="RSpec::Expectations::MultipleExpectationsNotMetError">Got 2 failures from failure aggregation block:

  1) expected: 1
          got: &quot;foo&quot;

     (compared using ==)

     ./spec/example_spec.rb:53:in `block (2 levels) in &lt;top (required)&gt;'

  2) expected: 2
          got: &quot;bar&quot;

     (compared using ==)

     ./spec/example_spec.rb:54:in `block (2 levels) in &lt;top (required)&gt;'</failure>
     </testcase>
</testsuite>
```