### PR TITLE
Adding failing spec number line

### DIFF
--- a/lib/rspec_junit_formatter.rb
+++ b/lib/rspec_junit_formatter.rb
@@ -59,6 +59,7 @@ private
       output << %{<failure}
       output << %{ message="#{escape(failure_message_for(example))}"}
       output << %{ type="#{escape(failure_type_for(example))}"}
+      output << %{ line_number="#{escape(failure_line_number_for(example))}"}
       output << %{>}
       output << escape(failure_for(example))
       output << %{</failure>}

--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -52,6 +52,10 @@ private
     strip_diff_colors(exception_for(example).to_s)
   end
 
+  def failure_line_number_for(example)
+    example.metadata[:line_number]
+  end
+
   def failure_for(example)
     exception = exception_for(example)
     message   = strip_diff_colors(exception.message)

--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -87,6 +87,10 @@ private
     strip_diff_colors(exception_for(example).to_s)
   end
 
+  def failure_line_number_for(notification)
+    notification.example.metadata[:line_number].to_s
+  end
+
   def failure_for(notification)
     strip_diff_colors(notification.message_lines.join("\n")) << "\n" << notification.formatted_backtrace.join("\n")
   end

--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -116,6 +116,7 @@ describe RspecJunitFormatter do
       child = testcase.element_children.first
       expect(child.name).to eql("failure")
       expect(child["message"]).not_to be_empty
+      expect(child["line_number"].to_i.class).to be(Integer)
       expect(child.text.strip).not_to be_empty
       expect(child.text.strip).not_to match(/\\e\[(?:\d+;?)+m/)
     end


### PR DESCRIPTION
This PR adds `line_number` attribute to `failure` property same as with JSON formatter: https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/formatters/json_formatter.rb#L95

This is helpful to know which test fails and in what line so you can point to it easily for example using "githublink.com/org/repo/file_name#L{line_number}"

### After
![image](https://github.com/user-attachments/assets/78b8d532-54fe-438e-b648-80c59c37a088)
